### PR TITLE
Net::FTP::List::Entry include Comparable

### DIFF
--- a/lib/net/ftp/list/entry.rb
+++ b/lib/net/ftp/list/entry.rb
@@ -1,5 +1,6 @@
 # Represents an entry of the FTP list. Gets returned when you parse a list.
 class Net::FTP::List::Entry
+  include Comparable
 
   ALLOWED_ATTRIBUTES = [:raw, :basename, :dir, :file, :symlink, :mtime, :filesize, :device, :server_type] #:nodoc:
 
@@ -14,16 +15,33 @@ class Net::FTP::List::Entry
     end
   end
 
-  # Tests for objects equality.
+  # Tests for objects equality (value and type).
   #
   # @param entry [Net::FTP::List::Entry] an entry of the FTP list.
   #
-  # @return [true, false] true if the objects are equal; false otherwise.
+  # @return [true, false] true if the objects are equal and have the same type; false otherwise.
   #
-  def ==(other)
-    return false if self.class != other.class
+  def eql?(other)
+    return false if !other.instance_of? self.class
+    return true if self.object_id == other.object_id
 
-    @raw == other.raw # if it's exactly the same line then the objects are the same
+    self.raw == other.raw # if it's exactly the same line then the objects are the same
+  end
+
+
+  # Compares the receiver against another object.
+  #
+  # @param (see #eql?)
+  #
+  # @return [Fixnum]  -1, 0, or +1 depending on whether the receiver is less than, equal to, or greater than the other object.
+  #
+  def <=>(other)
+    if other.instance_of? self.class
+      return self.filesize <=> other.filesize
+    elsif other.instance_of? Fixnum or other.instance_of? Integer or other.instance_of? Float
+      return self.filesize <=> other
+    end
+    raise ArgumentError.new('comparison of %s with %s failed!' % [self.class, other.class])
   end
 
   # The raw list entry string.

--- a/test/test_net_ftp_list_entry.rb
+++ b/test/test_net_ftp_list_entry.rb
@@ -8,11 +8,47 @@ class TestNetFTPEntry < Test::Unit::TestCase
     b = Net::FTP::List::Entry.new('foo2', {:basename => 'foo2'})
     c = Net::FTP::List::Entry.new('foo1', {:basename => 'foo1'})
 
-    assert_equal a, c
-    assert_equal a, a
-    assert_not_equal a, b
-    assert_not_equal a, 1
-    assert_not_equal a, 1.0
+    assert a.eql? c
+    assert a.eql? a
+    assert !a.eql?(b)
+    assert !a.eql?(1)
+    assert !a.eql?(1.0)
+  end
+
+  def test_comparison
+    raw1 = '-rw-r--r-- 1 root     other     1 Dec 31 23:59 file1'
+    raw2 = '-rw-r--r-- 1 root     other     2 Dec 31 23:59 file2'
+    raw3 = '-rw-r--r-- 1 root     other     3 Dec 31 23:59 file3'
+
+    file1 = Net::FTP::List.parse(raw1)
+    file2 = Net::FTP::List.parse(raw2)
+    file3 = Net::FTP::List.parse(raw3)
+
+    assert file2 > file1
+    assert file2 >= file1
+    assert file2 == file2
+    assert file2 <= file3
+    assert file2 < file3
+    assert !(file2 < file1)
+    assert !(file2 <= file1)
+    assert !(file2 == file1)
+    assert !(file2 == file3)
+    assert !(file2 > file3)
+    assert !(file2 >= file3)
+
+    assert !(file2 < 2)
+    assert !(file2 < 2.0)
+    assert file2 <= 2
+    assert file2 <= 2.0
+    assert file2 == 2
+    assert file2 == 2.0
+    assert !(file2 > 2)
+    assert !(file2 > 2.0)
+    assert file2 >= 2
+    assert file2 >= 2.0
+
+    assert_raise(ArgumentError) { assert file2 > nil }
+    assert_raise(ArgumentError) { assert file2 > true } # wrong class
   end
 
   def test_raise_on_unknown_options


### PR DESCRIPTION
Hello,

  I've implemented the Comparable module to more easily compare entries.
I've also produced unit tests that prove its working as expected and the necessary documentation.

cheers,
Steenzout
PS: unfortunately, I forgot to branch before I started making the changes.
