### PR TITLE
Fix unix symlinks without arrow

### DIFF
--- a/lib/net/ftp/list/unix.rb
+++ b/lib/net/ftp/list/unix.rb
@@ -72,7 +72,7 @@ class Net::FTP::List::Unix < Net::FTP::List::Parser
     # strip the symlink stuff we don't care about
     if symlink
       basename.sub!(/\s+\->(.+)$/, '')
-      symlink_destination = $1.strip
+      symlink_destination = $1.strip if $1
     end
 
     emit_entry(

--- a/test/test_net_ftp_list_unix.rb
+++ b/test/test_net_ftp_list_unix.rb
@@ -8,6 +8,7 @@ class TestNetFTPListUnix < Test::Unit::TestCase
     @other_dir = Net::FTP::List.parse         'drwxr-xr-x 8 1791     600      4096 Mar 11 07:57 forums'              rescue nil
     @spaces = Net::FTP::List.parse            'drwxrwxr-x 2 danial   danial     72 May 23 12:52 spaces suck'         rescue nil
     @symlink = Net::FTP::List.parse           'lrwxrwxrwx 1 danial   danial      4 Oct 30 15:26 bar -> /etc'         rescue nil
+    @empty_symlink = Net::FTP::List.parse     'lrwxrwxrwx 1 danial   danial      4 Oct 30 15:26 foo'                 rescue nil
     @older_date = Net::FTP::List.parse        '-rwxrwxrwx 1 owner    group  154112 Feb 15  2008 participando.xls'    rescue nil
     @block_dev = Net::FTP::List.parse         'brw-r----- 1 root     disk   1,   0 Apr 13  2006 ram0'                rescue nil
     @char_dev  = Net::FTP::List.parse         'crw-rw-rw- 1 root     root   1,   3 Apr 13  2006 null'                rescue nil
@@ -24,6 +25,7 @@ class TestNetFTPListUnix < Test::Unit::TestCase
     assert_equal "Unix", @other_dir.server_type,      'LIST unixish directory'
     assert_equal "Unix", @spaces.server_type,         'LIST unixish directory with spaces'
     assert_equal "Unix", @symlink.server_type,        'LIST unixish symlink'
+    assert_equal "Unix", @empty_symlink.server_type,  'LIST unixish symlink'
     assert_equal "Unix", @block_dev.server_type,      'LIST unix block device'
     assert_equal "Unix", @char_dev.server_type,       'LIST unix char device'
     assert_equal "Unix", @socket_dev.server_type,     'LIST unix socket device'


### PR DESCRIPTION
The OpenSSH SFTP client does not currently support arrows in symlinks (see https://unix.stackexchange.com/questions/366662/how-to-list-the-symbolic-links-with-sftp), so `Net::FTP::List.parse(sftp_command_output)` fails with following error:

```
NoMethodError: undefined method `strip' for nil:NilClass
	from net-ftp-list-3.2.10/lib/net/ftp/list/unix.rb:75:in `parse'

```
My PR fixes this error.